### PR TITLE
README for `fission-codes` GitHub org

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -16,6 +16,7 @@ Fission's true local-first, edge computing stack. Webnative empowers you to guil
 
 - [Webnative SDK](https://github.com/fission-codes/webnative)
 - [Webnative Docs](https://guide.fission.codes/)
+- [Webnative Whitepaper](https://github.com/fission-codes/whitepaper)
 - [Webnative Examples](https://github.com/webnative-examples)
 
 ## Connect with us!

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # Building protocols for the future of the Internet
 
-Fission is building the _data_, _auth_ & _compute_ primitives that enable true local-first edge applications.
+Fission is building the _data_, _identity_ & _compute_ primitives that enable true local-first edge applications.
 
 ## Working Groups
 
@@ -12,16 +12,17 @@ We don't get to the future alone. Fission collaborates with other developers and
 
 ## Webnative
 
-Fission's true local-first, edge computing stack. Webnative empowers you to guild fully distributed web applications without needing a complex backend.
+Fission's true local-first, edge computing stack. Webnative empowers you to build fully distributed web applications with auth and storage without needing a complex backend.
 
-- [Webnative SDK](https://github.com/fission-codes/webnative)
-- [Webnative Docs](https://guide.fission.codes/)
-- [Webnative Whitepaper](https://github.com/fission-codes/whitepaper)
-- [Webnative Examples](https://github.com/webnative-examples)
+- [SDK](https://github.com/fission-codes/webnative) - the base SDK for building Webnative apps
+- [Guide](https://guide.fission.codes/) - documentation on using Webnative
+- [App Template](https://github.com/webnative-examples/webnative-app-template) - clone-and-go template for quickly building a web app using Webnative.
+- [Examples](https://github.com/webnative-examples) - example apps built with Webnative.
+- [Whitepaper](https://github.com/fission-codes/whitepaper) - original whitepaper that outlines the Webnative vision.
 
 ## Connect with us!
 
 - [Follow us on Twitter](https://twitter.com/FISSIONcodes)
 - [Join our Discord](https://fission.codes/discord)
-- [Join our Discourse](https://talk.fission.codes/)
-- [Fission Events](https://talk.fission.codes/upcoming-events)
+- [Dive deeper on Discourse](https://talk.fission.codes/)
+- [Attend Fission Events](https://lu.ma/community/com-XuESjPQQHjh43pc/calendar)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,26 @@
+# Building protocols for the future of the Internet
+
+Fission is building the _data_, _auth_ & _compute_ primitives that enable true local-first edge applications.
+
+## Working Groups
+
+We don't get to the future alone. Fission collaborates with other developers and organizations through a variety of working groups.
+
+- [UCAN (User Controlled Authorization Networks) Working Group](https://github.com/ucan-wg) - a trustless, secure, local-first, user-originated authorization and revocation scheme.
+- [WNFS (Webnative Filesystem) Working Group](https://github.com/wnfs-wg/) - a versioned, logged, programmable, flexibly secure distributed file system.
+- [IPVM (Interplanetary Virtual Machine) Working Group](https://github.com/ipvm-wg) - an open, decentralized, and local-first execution layer for IPFS.
+
+## Webnative
+
+Fission's true local-first, edge computing stack. Webnative empowers you to guild fully distributed web applications without needing a complex backend.
+
+- [Webnative SDK](https://github.com/fission-codes/webnative)
+- [Webnative Docs](https://guide.fission.codes/)
+- [Webnative Examples](https://github.com/webnative-examples)
+
+## Connect with us!
+
+- [Follow us on Twitter](https://twitter.com/FISSIONcodes)
+- [Join our Discord](https://fission.codes/discord)
+- [Join our Discourse](https://talk.fission.codes/)
+- [Fission Events](https://talk.fission.codes/upcoming-events)


### PR DESCRIPTION
## Motivation

Fission's GitHub presence sprawls like Virginia Creeper in the summer. We need a top-level README for [the main Fission Codes GitHub Org](https://github.com/fission-codes) that directs folks to our multitudinous endeavors.

## Finish Line

Simple README that hits the high points while giving folks a decent idea of what Fission is/does.

README will get inserted into the top-level org page like so:
![readme-here](https://user-images.githubusercontent.com/27258/199077379-63fbbf95-79d8-4d50-a848-18f2c4564ae7.png)
